### PR TITLE
Show defaults to not recurse tree, add print

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpatialIndexing"
 uuid = "d4ead438-fe20-5cc5-a293-4fd39a41b74c"
 author = "Alexey Stukalov"
-version = "0.1.3"
+version = "0.1.4"
 
 [compat]
 julia = "1"

--- a/src/rtree/show.jl
+++ b/src/rtree/show.jl
@@ -1,4 +1,4 @@
-function Base.show(io::IO, tree::RTree)
+function Base.show(io::IO, tree::RTree; recurse::Bool=false)
     print(io, typeof(tree))
     print(io, "(variant="); print(io, tree.variant)
     print(io, ", tight_mbrs="); print(io, tree.tight_mbrs)
@@ -11,7 +11,7 @@ function Base.show(io::IO, tree::RTree)
     print(io, ", branch_capacity="); print(io, capacity(Branch, tree)); println(io, ")")
     print(io, length(tree)); print(io, " element(s) in "); print(io, height(tree));
     print(io, " level(s) ("); print(io, join(reverse(tree.nnodes_perlevel), ", ")); println(io, " node(s) per level):")
-    _show(io, tree.root, recurse=true, indent=1)
+    _show(io, tree.root, recurse=recurse, indent=1)
 end
 
 function _show(io::IO, node::Node; recurse::Bool=false, indent::Int=0)
@@ -34,4 +34,8 @@ function _show(io::IO, node::Node; recurse::Bool=false, indent::Int=0)
             end
         end
     end
+end
+
+function Base.print(io::IO, tree::RTree;)
+    show(io, tree; recurse=true)    
 end

--- a/test/rtree.jl
+++ b/test/rtree.jl
@@ -345,4 +345,43 @@ end
     end
 end
 
+@testset "show() and print()" begin
+    mbrs = Vector{SI.Rect{Float64, 2}}(
+        [
+            SI.Rect((0.0, 0.0), (2.0, 2.0)),
+            SI.Rect((-1.0, -1.0), (1.0, 1.0)),
+            SI.Rect((-1.0, 0.0), (1.0, 1.0)),
+            SI.Rect((0.0, -1.0), (1.0, 1.0)),
+            SI.Rect((1.0, 1.0), (2.0, 2.0)),
+        ]
+    )
+    tree = RTree{SI.dimtype(eltype(mbrs)), ndims(eltype(mbrs))}(Int, String, leaf_capacity=4, branch_capacity=4)
+    for (i, rmbr) in enumerate(mbrs)
+        insert!(tree, rmbr, i, string(i))
+    end
+
+    test_show_string = "$(typeof(tree))(variant=RTreeStar, tight_mbrs=true, nearmin_overlap=1, fill_factor=0.7, split_factor=0.4, reinsert_factor=0.3, leaf_capacity=4, branch_capacity=4)
+5 element(s) in 2 level(s) (1, 2 node(s) per level):
+ level=2 nchildren=2 mbr=((-1.0, -1.0), (2.0, 2.0))"
+    test_print_string = "$(typeof(tree))(variant=RTreeStar, tight_mbrs=true, nearmin_overlap=1, fill_factor=0.7, split_factor=0.4, reinsert_factor=0.3, leaf_capacity=4, branch_capacity=4)
+5 element(s) in 2 level(s) (1, 2 node(s) per level):
+ level=2 nchildren=2 mbr=((-1.0, -1.0), (2.0, 2.0)):
+  level=1 nchildren=3 mbr=((-1.0, -1.0), (1.0, 1.0)):
+   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((-1.0, -1.0), (1.0, 1.0)), 2, \"2\")
+   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((-1.0, 0.0), (1.0, 1.0)), 3, \"3\")
+   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((0.0, -1.0), (1.0, 1.0)), 4, \"4\")
+  level=1 nchildren=2 mbr=((0.0, 0.0), (2.0, 2.0)):
+   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((0.0, 0.0), (2.0, 2.0)), 1, \"1\")
+   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((1.0, 1.0), (2.0, 2.0)), 5, \"5\")"
+
+    io = IOBuffer()
+    show(io, tree)
+    @test String(take!(io)) == test_show_string
+    print(io, tree);
+    @test String(take!(io)) == test_print_string
+    show(io, tree; recurse=false)
+    @test String(take!(io)) == test_show_string
+    show(io, tree; recurse=true)
+    @test String(take!(io)) == test_print_string
+end
 end

--- a/test/rtree.jl
+++ b/test/rtree.jl
@@ -360,6 +360,8 @@ end
         insert!(tree, rmbr, i, string(i))
     end
 
+    eltyp = eltype(tree)
+    rectyp = eltype(mbrs)
     test_show_string = "$(typeof(tree))(variant=RTreeStar, tight_mbrs=true, nearmin_overlap=1, fill_factor=0.7, split_factor=0.4, reinsert_factor=0.3, leaf_capacity=4, branch_capacity=4)
 5 element(s) in 2 level(s) (1, 2 node(s) per level):
  level=2 nchildren=2 mbr=((-1.0, -1.0), (2.0, 2.0))"
@@ -367,12 +369,12 @@ end
 5 element(s) in 2 level(s) (1, 2 node(s) per level):
  level=2 nchildren=2 mbr=((-1.0, -1.0), (2.0, 2.0)):
   level=1 nchildren=3 mbr=((-1.0, -1.0), (1.0, 1.0)):
-   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((-1.0, -1.0), (1.0, 1.0)), 2, \"2\")
-   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((-1.0, 0.0), (1.0, 1.0)), 3, \"3\")
-   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((0.0, -1.0), (1.0, 1.0)), 4, \"4\")
+   $eltyp($rectyp((-1.0, -1.0), (1.0, 1.0)), 2, \"2\")
+   $eltyp($rectyp((-1.0, 0.0), (1.0, 1.0)), 3, \"3\")
+   $eltyp($rectyp((0.0, -1.0), (1.0, 1.0)), 4, \"4\")
   level=1 nchildren=2 mbr=((0.0, 0.0), (2.0, 2.0)):
-   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((0.0, 0.0), (2.0, 2.0)), 1, \"1\")
-   SpatialElem{Float64, 2, Int64, String}(SpatialIndexing.Rect{Float64, 2}((1.0, 1.0), (2.0, 2.0)), 5, \"5\")"
+   $eltyp($rectyp((0.0, 0.0), (2.0, 2.0)), 1, \"1\")
+   $eltyp($rectyp((1.0, 1.0), (2.0, 2.0)), 5, \"5\")"
 
     io = IOBuffer()
     show(io, tree)


### PR DESCRIPTION
This small update prevents Rtree objects from recursively printing when they are first created or just called in the REPL, unless the 'print' function is applied to it.

Should fix https://github.com/alyst/SpatialIndexing.jl/issues/9

I've tested it with testing scripts, per below:
```

using SpatialIndexing
using Random, Test

const SI=SpatialIndexing

Random.seed!(32123)
mbrs = Vector{SI.Rect{Float64, 3}}()
for i in 1:1000
    w, h, d = 5 .* rand(3)
    x, y, z = 50 .* randn(3)
    rmbr = SI.Rect((x-w, y-h, z-d), (x+w, y+h, z+d))
    push!(mbrs, rmbr)
end
tree = RTree{SI.dimtype(eltype(mbrs)), ndims(eltype(mbrs))}(Int, String, leaf_capacity = 20, branch_capacity = 20)
@test tree isa RTree{Float64, 3, SpatialElem{Float64, 3, Int, String}}
for (i, rmbr) in enumerate(mbrs)
    insert!(tree, rmbr, i, string(i))
    @test length(tree) == i
    @test tree.nelem_insertions == i
    @test SI.check(tree)
    #@debug "$i: len=$(length(tree)) height=$(SI.height(tree))"
end

tree  # defaults to show
@show tree  # doesn't print entire tree
print(tree)  # prints entire tree recursively
```