### PR TITLE
remove unused type parameter

### DIFF
--- a/src/rtree/bulk.jl
+++ b/src/rtree/bulk.jl
@@ -1,7 +1,7 @@
 # default branch fill strategy
 # returns the tuple:
 # the number of 1st dim slices and the number of child nodes in each slice
-function omt_branch_fill(tree::RTree; fill_factor::Number=1.0) where T<:Node
+function omt_branch_fill(tree::RTree; fill_factor::Number=1.0)
     @assert 0.0 <= fill_factor <= 1.0
     maxlen = ceil(Int, capacity(Branch, tree) * fill_factor)
     slicelen = ceil(Int, 0.75*sqrt(maxlen))


### PR DESCRIPTION
Removes a warning when using SpacialIndexing.jl on julia 1.8.3:

```
WARNING: method definition for #omt_branch_fill#55 at C:\Users\user\.julia\packages\SpatialIndexing\9p1Q1\src\rtree\bulk.jl:4 declares type variable T but does not use it.
```